### PR TITLE
add bboxFromCenter for x,y coords that lie at the center of the bbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ Convert tile xyz value to bbox of the form `[w, s, e, n]`
 
 Returns bbox array of values in form `[w, s, e, n]`.
 
+### `bboxFromCenter(x, y, zoom, tms_style, srs)`
+
+Convert tile xyz value to bbox of the form `[w, s, e, n]`
+Like `bbox` above, but x, y are assumed to lie at the center of the bbox.
+
 ### `xyz(bbox, zoom, tms_style, srs)`
 
 Convert bbox to xyz bounds
@@ -57,7 +62,7 @@ Returns {Object} XYZ bounds containing minX, maxX, minY, maxY properties.
 
 ### `convert(bbox, to)`
 
-Convert bbox from 900913 to WGS84 or vice versa 
+Convert bbox from 900913 to WGS84 or vice versa
 
 * `bbox` {Number} bbox in the form `[w, s, e, n]`.
 * `to` {String} projection of resulting bbox (WGS84|900913). (optional, default WGS84)

--- a/sphericalmercator.js
+++ b/sphericalmercator.js
@@ -90,6 +90,13 @@ SphericalMercator.prototype.bbox = function(x, y, zoom, tms_style, srs) {
     }
 };
 
+// Convert tile xyz value to bbox of the form `[w, s, e, n]`
+// like bbox(x, y, zoom, tms_style, srs), but x,y are assumed to lie
+// at the center of the bbox
+SphericalMercator.prototype.bboxFromCenter = function(x, y, zoom, tms_style, srs) {
+    return this.bbox(x - 0.5, y - 0.5, zoom, tms_style, srs);
+};
+
 // Convert bbox to xyx bounds
 //
 // - `bbox` {Number} bbox in the form `[w, s, e, n]`.


### PR DESCRIPTION
For my use case I'd like to generate a bounding box for x,y center coordinates. I have added a method `bboxFromCenter` that internally calls `bbox`.