### PR TITLE
Make sure x and y produced by xyz are valid

### DIFF
--- a/sphericalmercator.js
+++ b/sphericalmercator.js
@@ -111,8 +111,8 @@ SphericalMercator.prototype.xyz = function(bbox, zoom, tms_style, srs) {
     var x = [ Math.floor(px_ll[0] / this.size), Math.floor((px_ur[0] - 1) / this.size) ];
     var y = [ Math.floor(px_ur[1] / this.size), Math.floor((px_ll[1] - 1) / this.size) ];
     var bounds = {
-        minX: Math.min.apply(Math, x),
-        minY: Math.min.apply(Math, y),
+        minX: Math.min.apply(Math, x) < 0 ? 0 : Math.min.apply(Math, x),
+        minY: Math.min.apply(Math, y) < 0 ? 0 : Math.min.apply(Math, y),
         maxX: Math.max.apply(Math, x),
         maxY: Math.max.apply(Math, y)
     };

--- a/test/sphericalmercator.test.js
+++ b/test/sphericalmercator.test.js
@@ -40,6 +40,13 @@ tape('xyz-broken', function(assert) {
     assert.end();
 });
 
+tape('xyz-negative', function(assert) {
+    var extent = [-112.5, 85.0511, -112.5, 85.0511];
+    var xyz = sm.xyz(extent, 0);
+    assert.equal(xyz.minY, 0, 'returns zero for y value');
+    assert.end();
+});
+
 tape('xyz-fuzz', function(assert) {
     for (var i = 0; i < 1000; i++) {
         var x = [-180 + (360*Math.random()), -180 + (360*Math.random())];
@@ -81,10 +88,10 @@ tape('extents', function(assert) {
     );
     assert.deepEqual(
         sm.xyz([-240,-90,240,90],4,true,'WGS84'), {
-            minX: -3,
+            minX: 0,
             minY: 0,
             maxX: 15,
-            maxY: 20
+            maxY: 15
         },
         'Maximum extents enforced on conversion to tile ranges.'
     );


### PR DESCRIPTION
Ran into a situation where a `sm.xyz` was returning a `z/x/y` of `0/0/-1` for the extent `-112.5, 85.0511, -112.5, 85.0511`. Since node-mapnik's vector-tile constructor now throws an error whenever invalid z,x,y are passed to it, we were getting tm2z sources that failed profiling in tilelive-vector with `Tile does not exist`.

The current fix prevents values from going below 0 for minX and minY. @springmeyer let me know if you have a more elegant solution.

cc/ @tmcw @yhahn @flippmoke 