### PR TITLE
[WIP] Add failing test for px()

### DIFF
--- a/test/sphericalmercator.test.js
+++ b/test/sphericalmercator.test.js
@@ -97,3 +97,13 @@ tape('extents', function(assert) {
     );
     assert.end();
 });
+
+tape('px', function(assert) {
+    assert.deepEqual(
+        sm.px([-77.036556, 38.897708], 17),
+        [19193777, 25672129],
+        'returns pixel x/y of viewport, based on zoom level'
+    );
+
+    assert.end();
+});


### PR DESCRIPTION
This PR aims to triage a downstream bug in `mapbox/geo-viewport`, which _may_ be caused by `sm.px()` or `sm.ll()`.

The issue is discussed in https://github.com/mapbox/node-sphericalmercator/issues/17